### PR TITLE
Openstack: increase runner limit to 40

### DIFF
--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -38,7 +38,7 @@ cache_dir = "~/cache"
 
 [[runners]]
 name = "terraform/openstack"
-limit = 35
+limit = 40
 url = "https://gitlab.com/"
 token = "{{ terraform_openstack_token }}"
 executor = "custom"

--- a/test/config.toml
+++ b/test/config.toml
@@ -38,7 +38,7 @@ cache_dir = "~/cache"
 
 [[runners]]
 name = "terraform/openstack"
-limit = 35
+limit = 40
 url = "https://gitlab.com/"
 token = "terraform openstack gorgeous token"
 executor = "custom"


### PR DESCRIPTION
I think it's safe to increase to 40. We have 30 openstack runners in `.gitlab-ci.yml` in osbuild-composer and 16 of them are large (4 CPU, 8 GB RAM) and the rest are regular which are half of that. I've been watching our quota from time to time this week and I never saw usage bigger than ~122/150 CPUs and like 230/300 GB RAM (it's proportional, idk the exact RAM number). 

It would be a lot better if we could dynamically figure out the remaining quota and provision based on that, same for aws because we're only limited by the IP count for internal runners, but that will require some more work.