### PR TITLE
fix path to builds_dir and cache_dir of the shell runner

### DIFF
--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -28,8 +28,8 @@ name = "shell"
 url = "https://gitlab.com/"
 token = "{{ redhat_shell_token }}"
 executor = "shell"
-builds_dir = "~/builds-shell"
-cache_dir = "~/cache"
+builds_dir = "/home/gitlab-runner/builds-shell"
+cache_dir = "/home/gitlab-runner/cache"
 [runners.custom_build_dir]
 [runners.cache]
 [runners.cache.s3]

--- a/test/config.toml
+++ b/test/config.toml
@@ -28,8 +28,8 @@ name = "shell"
 url = "https://gitlab.com/"
 token = "shell magnificent token"
 executor = "shell"
-builds_dir = "~/builds-shell"
-cache_dir = "~/cache"
+builds_dir = "/home/gitlab-runner/builds-shell"
+cache_dir = "/home/gitlab-runner/cache"
 [runners.custom_build_dir]
 [runners.cache]
 [runners.cache.s3]


### PR DESCRIPTION
It must be absolute apparently.