### PR TITLE
Reduce the ammount of concurent jobs

### DIFF
--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -1,4 +1,4 @@
-concurrent = 500
+concurrent = 350
 check_interval = 0
 
 [session_server]
@@ -6,7 +6,7 @@ session_timeout = 1800
 
 [[runners]]
 name = "terraform"
-limit = 455
+limit = 300
 url = "https://gitlab.com/"
 token = "{{ redhat_terraform_token }}"
 executor = "custom"

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,4 +1,4 @@
-concurrent = 500
+concurrent = 350
 check_interval = 0
 
 [session_server]
@@ -6,7 +6,7 @@ session_timeout = 1800
 
 [[runners]]
 name = "terraform"
-limit = 455
+limit = 300
 url = "https://gitlab.com/"
 token = "terraform awesome token"
 executor = "custom"


### PR DESCRIPTION
When too many pipelines run at the same time the whole CI breaks.
Reducing the ammount of concurent jobs should help.