### PR TITLE
Increase Openstack runner limit

### DIFF
--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -1,4 +1,4 @@
-concurrent = 350
+concurrent = 380
 check_interval = 0
 
 [session_server]
@@ -38,7 +38,7 @@ cache_dir = "/home/gitlab-runner/cache"
 
 [[runners]]
 name = "terraform/openstack"
-limit = 40
+limit = 70
 url = "https://gitlab.com/"
 token = "{{ redhat_terraform_openstack_token }}"
 executor = "custom"

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,4 +1,4 @@
-concurrent = 350
+concurrent = 380
 check_interval = 0
 
 [session_server]
@@ -38,7 +38,7 @@ cache_dir = "/home/gitlab-runner/cache"
 
 [[runners]]
 name = "terraform/openstack"
-limit = 40
+limit = 70
 url = "https://gitlab.com/"
 token = "terraform openstack gorgeous token"
 executor = "custom"


### PR DESCRIPTION
We have switched all our jobs to use medium runners. This means we can
safely increase the limit of concurent jobs in Openstack. With this
setup it will leave quota for 5 machines which can be used by osbuild CI
for Openstack boot testing.

I've already made the manual change on the runner.