### PR TITLE
Add GCP CI runner

### DIFF
--- a/config.toml.tpl
+++ b/config.toml.tpl
@@ -54,3 +54,22 @@ prepare_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/prepare"
 prepare_exec_timeout = 43200
 run_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/exec"
 cleanup_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/cleanup"
+
+[[runners]]
+name = "terraform/gcp"
+limit = 200
+url = "https://gitlab.com/"
+token = "{{ redhat_terraform_gcp_token }}"
+executor = "custom"
+builds_dir = "~/builds-gcp"
+cache_dir = "~/cache"
+[runners.custom_build_dir]
+[runners.cache]
+[runners.cache.s3]
+[runners.cache.gcs]
+[runners.cache.azure]
+[runners.custom]
+prepare_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/prepare"
+prepare_exec_timeout = 43200
+run_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/exec"
+cleanup_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/cleanup"

--- a/test/config.toml
+++ b/test/config.toml
@@ -54,3 +54,22 @@ prepare_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/prepare"
 prepare_exec_timeout = 43200
 run_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/exec"
 cleanup_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/cleanup"
+
+[[runners]]
+name = "terraform/gcp"
+limit = 200
+url = "https://gitlab.com/"
+token = "terraform gcp glorious token"
+executor = "custom"
+builds_dir = "~/builds-gcp"
+cache_dir = "~/cache"
+[runners.custom_build_dir]
+[runners.cache]
+[runners.cache.s3]
+[runners.cache.gcs]
+[runners.cache.azure]
+[runners.custom]
+prepare_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/prepare"
+prepare_exec_timeout = 43200
+run_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/exec"
+cleanup_exec = "/home/gitlab-runner/gitlab-ci-terraform-executor/cleanup"

--- a/test/data.json
+++ b/test/data.json
@@ -1,5 +1,6 @@
 {
   "redhat_terraform_token": "terraform awesome token",
   "redhat_shell_token": "shell magnificent token",
-  "redhat_terraform_openstack_token": "terraform openstack gorgeous token"
+  "redhat_terraform_openstack_token": "terraform openstack gorgeous token",
+  "redhat_terraform_gcp_token": "terraform gcp glorious token"
 }


### PR DESCRIPTION
We can now provision CI runners in GCP so let's add them.